### PR TITLE
Fix capitalisation of 'macOS'

### DIFF
--- a/AlDente/ContentView.swift
+++ b/AlDente/ContentView.swift
@@ -81,7 +81,7 @@ struct settings<Content: View>: View {
                         self.presenter.setValue(value: Float(self.presenter.value))
                     }
                 )) {
-                    Text("Use MacOS battery scale")
+                    Text("Use macOS battery scale")
                 }.padding()
                 
                 Spacer()


### PR DESCRIPTION
Correct 'MacOS' to 'macOS'. Just a small thing, but something I noticed.